### PR TITLE
catch 0. warning in dti predict

### DIFF
--- a/dipy/reconst/dti.py
+++ b/dipy/reconst/dti.py
@@ -682,7 +682,9 @@ def tensor_prediction(dti_params, gtab, S0):
     evecs = dti_params[..., 3:].reshape(dti_params.shape[:-1] + (3, 3))
     qform = vec_val_vect(evecs, evals)
     del evals, evecs
-    lower_tri = lower_triangular(qform, S0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        lower_tri = lower_triangular(qform, S0)
     del qform
 
     D = design_matrix(gtab)

--- a/dipy/reconst/tests/test_dti.py
+++ b/dipy/reconst/tests/test_dti.py
@@ -663,6 +663,9 @@ def test_predict():
     assert_array_almost_equal(dmfit.predict(gtab, S0=100), S)
     assert_array_almost_equal(dm.predict(dmfit.model_params, S0=100), S)
 
+    # All signals should be 0 if the b0 is 0.
+    assert_array_almost_equal(dmfit.predict(gtab, S0=0.), 0.)
+
     fdata, fbvals, fbvecs = get_data()
     data = nib.load(fdata).get_data()
     # Make the data cube a bit larger:


### PR DESCRIPTION
`lower_triangular` raises a warning if `S0` has 0s in it. This is normal for large data sets with background so we catch the warning. 
