### PR TITLE
Drop py2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       dist: xenial
       env:
         # Check these values against requirements.txt and dipy/info.py
-        - DEPENDS="cython==0.25.1 numpy==1.8.2 scipy==1.0 nibabel==2.3.0 h5py==2.4.0"
+        - DEPENDS="cython==0.29 numpy==1.8.2 scipy==1.0 nibabel==2.4.0 h5py==2.4.0"
     - python: 3.7
       dist: xenial
       env:

--- a/dipy/info.py
+++ b/dipy/info.py
@@ -77,10 +77,10 @@ MIT licenses.
 
 # versions for dependencies
 # Check these versions against .travis.yml and requirements.txt
-CYTHON_MIN_VERSION = '0.25.1'
-NUMPY_MIN_VERSION = '1.7.1'
-SCIPY_MIN_VERSION = '0.9'
-NIBABEL_MIN_VERSION = '2.3.0'
+CYTHON_MIN_VERSION = '0.29'
+NUMPY_MIN_VERSION = '1.8.2'
+SCIPY_MIN_VERSION = '1.0'
+NIBABEL_MIN_VERSION = '2.4.0'
 H5PY_MIN_VERSION = '2.4.0'
 
 # Main setup parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Check against .travis.yml file and dipy/info.py
-cython>=0.25.1
-numpy>=1.7.1
-scipy>=0.9
-nibabel>=2.3.0
+cython>=0.29
+numpy>=1.8.2
+scipy>=1.0
+nibabel>=2.4.0
 h5py>=2.4.0

--- a/setup_egg.py
+++ b/setup_egg.py
@@ -4,6 +4,6 @@
 """Wrapper to run setup.py using setuptools."""
 
 if __name__ == '__main__':
-    execfile('setup.py', dict(__name__='__main__',
-                              __file__='setup.py', # needed in setup.py
-                              force_setuptools=True))
+    exec('setup.py', dict(__name__='__main__',
+                          __file__='setup.py',  # needed in setup.py
+                          force_setuptools=True))


### PR DESCRIPTION
- Quick fix for some build issue on Travis.
- Update some minimun version
- `execfile` does not exist anymore on python 3.7. So we use `exec` instead
- the minimum version for Cython and python 3.7 is Cython 0.29.  More info [here](https://cython.readthedocs.io/en/latest/src/changes.html). 
- I updated Nibabel minimum version to avoid some Streamlines issue

Reference: https://github.com/nipy/dipy/pull/1775