### PR TITLE
[BUG FIX] removed **kwargs from ray remote func

### DIFF
--- a/dipy/utils/parallel.py
+++ b/dipy/utils/parallel.py
@@ -113,7 +113,7 @@ def paramap(func, in_list, out_shape=None, n_jobs=-1, engine="ray",
                     )
                 },)
 
-        func = ray.remote(func, **kwargs)
+        func = ray.remote(func)
         results = ray.get([func.remote(ii, *func_args, **func_kwargs)
                           for ii in in_list])
 


### PR DESCRIPTION
Ray does not support arbitrary keyword arguments, so we cannot pass **kwargs into ray.remote()